### PR TITLE
Add new skipping rules

### DIFF
--- a/lib/mumukit/flow/assignment.rb
+++ b/lib/mumukit/flow/assignment.rb
@@ -20,6 +20,7 @@ module Mumukit::Flow
     required :children
     required :submitter
     required :parent
+    required :tags
 
     delegate :easy?, :hard?, :should_retry?, to: :difficulty
 
@@ -92,6 +93,10 @@ module Mumukit::Flow
       # a cada item hijo pedirle su assignment y quedarse con los que no tienen o lo tinen en pending
       item_assignments = siblings.map { |it| [it.item, it] }.to_h
       sibling_items.reject { |it| item_assignments[it]&.finished?  }
+    end
+
+    def solved_sibling_items
+      parent.children.select { |assignment| assignment.passed? }
     end
   end
 end

--- a/lib/mumukit/flow/assignment.rb
+++ b/lib/mumukit/flow/assignment.rb
@@ -13,6 +13,7 @@ module Mumukit::Flow
 
     include Mumukit::Flow::Node
     include Mumukit::Flow::Assignment::Closing
+    include Mumukit::Flow::Assignment::Difficulty
     include Mumukit::Flow::Assignment::Suggesting
 
     required :item
@@ -20,12 +21,6 @@ module Mumukit::Flow
     required :children
     required :submitter
     required :parent
-
-    delegate :easy?, :hard?, :should_retry?, to: :difficulty
-
-    def difficulty
-      Mumukit::Flow::Difficulty.new(level)
-    end
 
     def level
       if has_children?

--- a/lib/mumukit/flow/assignment.rb
+++ b/lib/mumukit/flow/assignment.rb
@@ -93,6 +93,10 @@ module Mumukit::Flow
       (self.item.tags - item.tags).empty?
     end
 
+    def item_has?(tag)
+      item.tags.include?(tag)
+    end
+
     private
 
     # Overridable for better performance

--- a/lib/mumukit/flow/assignment.rb
+++ b/lib/mumukit/flow/assignment.rb
@@ -20,7 +20,6 @@ module Mumukit::Flow
     required :children
     required :submitter
     required :parent
-    required :tags
 
     delegate :easy?, :hard?, :should_retry?, to: :difficulty
 
@@ -86,6 +85,14 @@ module Mumukit::Flow
       siblings.any? &:hard?
     end
 
+    def children_passed_assignments
+      children.select { |assignment| assignment.passed? }
+    end
+
+    def item_similar_to?(item)
+      (self.item.tags - item.tags).empty?
+    end
+
     private
 
     # Overridable for better performance
@@ -93,10 +100,6 @@ module Mumukit::Flow
       # a cada item hijo pedirle su assignment y quedarse con los que no tienen o lo tinen en pending
       item_assignments = siblings.map { |it| [it.item, it] }.to_h
       sibling_items.reject { |it| item_assignments[it]&.finished?  }
-    end
-
-    def solved_sibling_items
-      parent.children.select { |assignment| assignment.passed? }
     end
   end
 end

--- a/lib/mumukit/flow/assignment/suggesting.rb
+++ b/lib/mumukit/flow/assignment/suggesting.rb
@@ -10,8 +10,6 @@ module Mumukit::Flow::Assignment
       if end_reached?
         if pending_items?
           Mumukit::Flow::Suggestion::Revisit.new(first_pending_item)
-        elsif hard_assignments?
-          Mumukit::Flow::Suggestion::Retry.new(first_hard_assignment.item)
         else
           Mumukit::Flow::Suggestion::None
         end

--- a/lib/mumukit/flow/assignment/suggesting.rb
+++ b/lib/mumukit/flow/assignment/suggesting.rb
@@ -14,15 +14,36 @@ module Mumukit::Flow::Assignment
           Mumukit::Flow::Suggestion::None
         end
       else
-        if next_item_suggestion_type == :learning
-          Mumukit::Flow::Suggestion::Skip.new(next_learning_item)
+        if should_skip_next_item?
+          Mumukit::Flow::Suggestion::Skip.new(next_item)
         else
-          Mumukit::Flow::Suggestion::Continue.new(next_practice_item)
+          Mumukit::Flow::Suggestion::Continue.new(next_item)
         end
       end
     end
 
     private
+
+    def should_skip_next_item?
+      at_least_two_similar_easy_assignments?
+    end
+
+    def at_least_two_similar_easy_assignments?
+      assignments = similar_solved_assignments
+      assignments.count >= 2 && (solved_most_easily? assignments)
+    end
+
+    def similar_solved_assignments
+      solved_sibling_items.select { |item| has_all? item.item.tags, next_item.tags }
+    end
+
+    def has_all?(tags, other_tags)
+      (tags - other_tags).empty?
+    end
+
+    def solved_most_easily?(items)
+      items.count { |item| item.easy? } > items.count / 2
+    end
 
     def next_learning_item
       next_items.find { |it| it.learning? } || next_item

--- a/lib/mumukit/flow/assignment/suggesting.rb
+++ b/lib/mumukit/flow/assignment/suggesting.rb
@@ -25,19 +25,22 @@ module Mumukit::Flow::Assignment
     private
 
     def should_skip_next_item?
-      at_least_two_similar_easy_assignments? unless next_item.learning?
+      similar_easy_assignments_for_every_tag? unless next_item.learning?
     end
 
-    def at_least_two_similar_easy_assignments?
-      assignments = similar_solved_assignments
-      assignments.count >= 2 && (solved_most_easily? assignments)
+    def similar_easy_assignments_for_every_tag?
+      next_item.tags.all? { |tag| easy_assignments_with(tag).count >= 2 }
     end
 
-    def similar_solved_assignments
-      parent.children_passed_assignments.select { |assignment| assignment.item_similar_to?(next_item) }
+    def easy_assignments_with(tag)
+      parent_passed_assignments.select { |assignment| assignment.easy? && assignment.item_has?(tag) }
     end
 
-    def solved_most_easily?(assignments)
+    def parent_passed_assignments
+      parent.children_passed_assignments
+    end
+
+    def passed_most_easily?(assignments)
       assignments.count { |assignment| assignment.easy? } > assignments.count / 2
     end
   end

--- a/lib/mumukit/flow/assignment/suggesting.rb
+++ b/lib/mumukit/flow/assignment/suggesting.rb
@@ -15,7 +15,7 @@ module Mumukit::Flow::Assignment
         end
       else
         if next_item_suggestion_type == :learning
-          Mumukit::Flow::Suggestion::FastForward.new(next_learning_item)
+          Mumukit::Flow::Suggestion::Skip.new(next_learning_item)
         else
           Mumukit::Flow::Suggestion::Continue.new(next_practice_item)
         end

--- a/lib/mumukit/flow/assignment/suggesting.rb
+++ b/lib/mumukit/flow/assignment/suggesting.rb
@@ -34,23 +34,11 @@ module Mumukit::Flow::Assignment
     end
 
     def similar_solved_assignments
-      solved_sibling_items.select { |item| has_all? item.item.tags, next_item.tags }
+      parent.children_passed_assignments.select { |assignment| assignment.item_similar_to?(next_item) }
     end
 
-    def has_all?(tags, other_tags)
-      (tags - other_tags).empty?
-    end
-
-    def solved_most_easily?(items)
-      items.count { |item| item.easy? } > items.count / 2
-    end
-
-    def next_learning_item
-      next_items.find { |it| it.learning? } || next_item
-    end
-
-    def next_practice_item
-      next_items.find { |it| it.practice? } || next_item
+    def solved_most_easily?(assignments)
+      assignments.count { |assignment| assignment.easy? } > assignments.count / 2
     end
   end
 end

--- a/lib/mumukit/flow/assignment/suggesting.rb
+++ b/lib/mumukit/flow/assignment/suggesting.rb
@@ -25,7 +25,7 @@ module Mumukit::Flow::Assignment
     private
 
     def should_skip_next_item?
-      at_least_two_similar_easy_assignments?
+      at_least_two_similar_easy_assignments? unless next_item.learning?
     end
 
     def at_least_two_similar_easy_assignments?

--- a/lib/mumukit/flow/difficulty.rb
+++ b/lib/mumukit/flow/difficulty.rb
@@ -1,7 +1,7 @@
 module Mumukit::Flow::Assignment
   module Difficulty
     def easy?
-      level <= 3
+      closed? && level <= 3
     end
 
     def hard?

--- a/lib/mumukit/flow/difficulty.rb
+++ b/lib/mumukit/flow/difficulty.rb
@@ -1,11 +1,5 @@
-module Mumukit::Flow
-  class Difficulty
-    attr_reader :level
-
-    def initialize(level = 0)
-      @level = level
-    end
-
+module Mumukit::Flow::Assignment
+  module Difficulty
     def easy?
       level <= 3
     end

--- a/lib/mumukit/flow/difficulty.rb
+++ b/lib/mumukit/flow/difficulty.rb
@@ -7,13 +7,5 @@ module Mumukit::Flow::Assignment
     def hard?
       level >= 10
     end
-
-    def should_retry?
-      hard?
-    end
-
-    def next_item_suggestion_type
-      easy? ? :learning : :practice
-    end
   end
 end

--- a/lib/mumukit/flow/suggestion.rb
+++ b/lib/mumukit/flow/suggestion.rb
@@ -21,8 +21,5 @@ module Mumukit::Flow
 
     class Revisit < Some
     end
-
-    class Retry < Some
-    end
   end
 end

--- a/lib/mumukit/flow/suggestion.rb
+++ b/lib/mumukit/flow/suggestion.rb
@@ -16,7 +16,10 @@ module Mumukit::Flow
     class Continue < Some
     end
 
-    class FastForward < Some
+    class Skip < Some
+    end
+
+    class Reinforce < Some
     end
 
     class Revisit < Some

--- a/mumukit-flow.gemspec
+++ b/mumukit-flow.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "mumukit-core", "~> 1.2"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/mumukit/assignment_spec.rb
+++ b/spec/mumukit/assignment_spec.rb
@@ -10,8 +10,8 @@ describe Mumukit::Flow::Assignment do
   let!(:assignments) { assignments_for(exercises) }
   let(:assignment) { assignments[0] }
 
-  describe 'submissions and difficulty' do
-    context 'when an assignment is passed on one try' do
+  describe 'assignment is passed' do
+    context 'in one try' do
       before do
         assignment.accept_submission_status! :passed
       end
@@ -20,17 +20,12 @@ describe Mumukit::Flow::Assignment do
         expect(assignment.submissions_count).to eq 1
       end
 
-      it 'should be easy' do
-        expect(assignment.easy?).to be true
-        expect(assignment.hard?).to be false
-      end
-
       it 'should know its status' do
         expect(assignment.status).to eq :passed
       end
     end
 
-    context 'when an assignment is passed after five tries' do
+    context 'in five tries' do
       before do
         4.times { assignment.accept_submission_status! :failed }
         assignment.accept_submission_status! :passed
@@ -40,17 +35,12 @@ describe Mumukit::Flow::Assignment do
         expect(assignment.submissions_count).to eq 5
       end
 
-      it 'should not be easy or hard' do
-        expect(assignment.easy?).to be false
-        expect(assignment.hard?).to be false
-      end
-
       it 'should know its status' do
         expect(assignment.status).to eq :passed
       end
     end
 
-    context 'when an assignment is passed after ten tries' do
+    context 'in ten tries' do
       before do
         9.times { assignment.accept_submission_status! :failed }
         assignment.accept_submission_status! :passed
@@ -60,41 +50,31 @@ describe Mumukit::Flow::Assignment do
         expect(assignment.submissions_count).to eq 10
       end
 
-      it 'should be hard' do
-        expect(assignment.easy?).to be false
-        expect(assignment.hard?).to be true
-      end
-
       it 'should know its status' do
         expect(assignment.status).to eq :passed
       end
     end
+  end
 
-    context 'when an assignment is failed twice' do
-      before do
-        2.times { assignment.accept_submission_status! :failed }
-      end
+  describe 'assignment is failed' do
+    before do
+      assignment.accept_submission_status! :failed
+    end
 
-      it 'should count submissions accordingly' do
-        expect(assignment.submissions_count).to eq 2
-      end
+    it 'should count submissions accordingly' do
+      expect(assignment.submissions_count).to eq 1
+    end
 
-      it 'should not be easy or hard' do
-        expect(assignment.easy?).to be false
-        expect(assignment.hard?).to be false
-      end
-
-      it 'should know its status' do
-        expect(assignment.status).to eq :failed
-      end
+    it 'should know its status' do
+      expect(assignment.status).to eq :failed
     end
   end
 
   describe 'items' do
-    context 'for the last assignment' do
+    context 'last assignment' do
       let(:assignment) { assignments[2] }
 
-      it 'should know the assignments item' do
+      it 'should know its item' do
         expect(assignment.item).to eq exercises[2]
       end
 
@@ -103,8 +83,8 @@ describe Mumukit::Flow::Assignment do
       end
     end
 
-    context 'for a non-trailing assignment' do
-      it 'should know the assignments item' do
+    context 'non-trailing assignment' do
+      it 'should know its item' do
         expect(assignment.item).to eq exercises[0]
       end
 

--- a/spec/mumukit/assignment_spec.rb
+++ b/spec/mumukit/assignment_spec.rb
@@ -178,4 +178,90 @@ describe Mumukit::Flow::Assignment do
       end
     end
   end
+
+  describe 'exercises with different tags' do
+    context 'when exercise with tag A and exercise with tag B were solved easily' do
+      let(:exercises) { [
+          DemoExercise.new(:learning, ['A']),
+          DemoExercise.new(:learning, ['B']),
+          DemoExercise.new(:practice)]
+      }
+
+      let!(:assignments) { assignments_for(exercises) }
+      let(:assignment) { assignments[1] }
+
+      before do
+        assignments[0].accept_submission_status! :passed
+        assignment.accept_submission_status! :passed
+      end
+
+      it 'should suggest continuing with the next exercise whatever its tag' do
+        expect(assignment.next_suggested_item).to eq exercises[2]
+        expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue
+      end
+    end
+
+    context 'when exercise with tag AB and exercise with tag A were solved easily' do
+      let(:exercises) { [
+          DemoExercise.new(:learning, ['A', 'B']),
+          DemoExercise.new(:learning, ['A'])]
+      }
+
+      let!(:assignments) { assignments_for(exercises) }
+      let!(:assignment) { assignments[1] }
+
+      before do
+        assignments[0].accept_submission_status! :passed
+        assignment.accept_submission_status! :passed
+      end
+
+      context 'next exercise is learning with any tag' do
+        before do
+          exercises[2] = DemoExercise.new(:learning)
+          assignments_for(exercises)
+        end
+
+        it 'should suggest continuing' do
+          expect(assignment.next_suggested_item).to eq exercises[2]
+          expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue
+        end
+      end
+
+      context 'next exercise is practice with tag A' do
+        before do
+          exercises[2] = DemoExercise.new(:practice, ['A'])
+          assignments_for(exercises)
+        end
+
+        it 'should suggest skipping' do
+          expect(assignment.next_suggested_item).to eq exercises[2]
+          expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Skip
+        end
+      end
+
+      context 'next exercise is practice with tag B' do
+        before do
+          exercises[2] = DemoExercise.new(:practice, ['B'])
+          assignments_for(exercises)
+        end
+
+        it 'should suggest continuing' do
+          expect(assignment.next_suggested_item).to eq exercises[2]
+          expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue
+        end
+      end
+
+      context 'next exercise is practice with tag AB' do
+        before do
+          exercises[2] = DemoExercise.new(:practice, ['A', 'B'])
+          assignments_for(exercises)
+        end
+
+        it 'should suggest continuing' do
+          expect(assignment.next_suggested_item).to eq exercises[2]
+          expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue
+        end
+      end
+    end
+  end
 end

--- a/spec/mumukit/assignment_spec.rb
+++ b/spec/mumukit/assignment_spec.rb
@@ -116,7 +116,7 @@ describe Mumukit::Flow::Assignment do
           it { expect(assignment.next_items).to eq [exercises[1], exercises[2]] }
 
           it { expect(assignment.next_suggested_item).to eq exercises[2] }
-          it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::FastForward }
+          it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Skip }
         end
 
         context 'assignment is normal' do

--- a/spec/mumukit/assignment_spec.rb
+++ b/spec/mumukit/assignment_spec.rb
@@ -1,193 +1,167 @@
 require 'spec_helper'
 
 describe Mumukit::Flow::Assignment do
-  context 'complete assignments' do
-    let!(:guide) { DemoGuide.new(exercises) }
-    let(:exercises) { [
-      DemoExercise.new(:learning),
-      DemoExercise.new(:practice),
-      DemoExercise.new(:learning)
-    ] }
 
-    let!(:guide_assignment) { DemoGuideAssignment.new(guide, exercise_assignments) }
-    let(:exercise_assignments) { [
-      DemoExerciseAssignment.new(exercises[0]),
-      DemoExerciseAssignment.new(exercises[1]),
-      DemoExerciseAssignment.new(exercises[2])
-    ] }
+  let(:exercises) { [
+    DemoExercise.new(:learning),
+    DemoExercise.new(:learning),
+    DemoExercise.new(:practice)]
+  }
 
-    context 'when item is last in path' do
-      let(:assignment) { exercise_assignments[2] }
+  let!(:assignments) { assignments_for(exercises) }
+  let(:assignment) { assignments[0] }
 
-      context 'when previous exercises have being solved easily' do
-        before do
-          exercise_assignments[0].accept_submission_status! :passed
-          exercise_assignments[1].accept_submission_status! :passed
-          assignment.accept_submission_status! :passed
-        end
-
-        it { expect(assignment.item).to eq exercises[2] }
-        it { expect(assignment.next_item).to eq nil }
-        it { expect(assignment.next_items).to eq [] }
-
-        it { expect(assignment.next_item_suggestion).to be Mumukit::Flow::Suggestion::None }
+  describe 'submissions and difficulty' do
+    context 'when an assignment is passed on one try' do
+      before do
+        assignment.accept_submission_status! :passed
       end
 
-      context 'when previous exercises have being normally solved' do
-        before do
-          exercise_assignments[0].accept_submission_status! :passed
-          5.times { exercise_assignments[1].accept_submission_status! :failed }
-          exercise_assignments[1].accept_submission_status! :passed
-          assignment.accept_submission_status! :passed
-        end
-
-        it { expect(assignment.item).to eq exercises[2] }
-        it { expect(assignment.next_item).to eq nil }
-        it { expect(assignment.next_items).to eq [] }
-
-        it { expect(assignment.next_suggested_item).to eq nil }
-        it { expect(assignment.next_item_suggestion).to be Mumukit::Flow::Suggestion::None }
+      it 'should count submissions accordingly' do
+        expect(assignment.submissions_count).to eq 1
       end
 
-      context 'when previous exercises have being hard to solve' do
-        before do
-          exercise_assignments[0].accept_submission_status! :passed
-          11.times { exercise_assignments[1].accept_submission_status! :failed }
-          exercise_assignments[1].accept_submission_status! :passed
-          assignment.accept_submission_status! :passed
-        end
-
-        it { expect(assignment.item).to eq exercises[2] }
-        it { expect(assignment.next_item).to eq nil }
-        it { expect(assignment.next_items).to eq [] }
-
-        it { expect(assignment.next_suggested_item).to eq nil }
-        it { expect(assignment.next_item_suggestion).to be Mumukit::Flow::Suggestion::None }
+      it 'should be easy' do
+        expect(assignment.easy?).to be true
+        expect(assignment.hard?).to be false
       end
 
-      context 'when there is a single pending exercises' do
-        before do
-          exercise_assignments[0].accept_submission_status! :passed
-          assignment.accept_submission_status! :passed
-        end
-
-        it { expect(assignment.item).to eq exercises[2] }
-        it { expect(assignment.next_item).to eq nil }
-        it { expect(assignment.next_items).to eq [] }
-
-        it { expect(assignment.next_suggested_item).to eq exercises[1] }
-        it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Revisit }
-      end
-
-      context 'when there are multiple pending exercises' do
-        before do
-          assignment.accept_submission_status! :passed
-        end
-
-        it { expect(assignment.item).to eq exercises[2] }
-        it { expect(assignment.next_item).to eq nil }
-        it { expect(assignment.next_items).to eq [] }
-
-        it { expect(assignment.next_suggested_item).to eq exercises[0] }
-        it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Revisit }
+      it 'should know its status' do
+        expect(assignment.status).to eq :passed
       end
     end
 
-    context 'when item is not last in path' do
-      let(:assignment) { exercise_assignments[0] }
+    context 'when an assignment is passed after five tries' do
+      before do
+        4.times { assignment.accept_submission_status! :failed }
+        assignment.accept_submission_status! :passed
+      end
 
-      describe 'practice suggestion flow' do
-        context 'assignment is easy' do
-          before do
-            assignment.accept_submission_status! :failed
-            assignment.accept_submission_status! :failed
-            assignment.accept_submission_status! :passed
-          end
+      it 'should count submissions accordingly' do
+        expect(assignment.submissions_count).to eq 5
+      end
 
-          it { expect(assignment.submissions_count).to eq 3 }
-          it { expect(assignment.status).to eq :passed }
-          it { expect(assignment.easy?).to be true }
-          it { expect(assignment.hard?).to be false }
-          it { expect(assignment.should_retry?).to be false }
-          it { expect(assignment.next_item_suggestion_type).to eq :learning }
+      it 'should not be easy or hard' do
+        expect(assignment.easy?).to be false
+        expect(assignment.hard?).to be false
+      end
 
-          it { expect(assignment.item).to eq exercises[0] }
-          it { expect(assignment.next_item).to eq exercises[1] }
-          it { expect(assignment.next_items).to eq [exercises[1], exercises[2]] }
+      it 'should know its status' do
+        expect(assignment.status).to eq :passed
+      end
+    end
 
-          it { expect(assignment.next_suggested_item).to eq exercises[1] }
-          it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue }
-        end
+    context 'when an assignment is passed after ten tries' do
+      before do
+        9.times { assignment.accept_submission_status! :failed }
+        assignment.accept_submission_status! :passed
+      end
 
-        context 'assignment is normal' do
-          before do
-            5.times { assignment.accept_submission_status! :failed }
-            assignment.accept_submission_status! :passed
-          end
+      it 'should count submissions accordingly' do
+        expect(assignment.submissions_count).to eq 10
+      end
 
-          it { expect(assignment.submissions_count).to eq 6 }
-          it { expect(assignment.status).to eq :passed }
-          it { expect(assignment.easy?).to be false }
-          it { expect(assignment.hard?).to be false }
-          it { expect(assignment.should_retry?).to be false }
-          it { expect(assignment.next_item_suggestion_type).to eq :practice }
+      it 'should be hard' do
+        expect(assignment.easy?).to be false
+        expect(assignment.hard?).to be true
+      end
 
-          it { expect(assignment.item).to eq exercises[0] }
-          it { expect(assignment.next_item).to eq exercises[1] }
-          it { expect(assignment.next_items).to eq [exercises[1], exercises[2]] }
+      it 'should know its status' do
+        expect(assignment.status).to eq :passed
+      end
+    end
 
-          it { expect(assignment.next_suggested_item).to eq exercises[1] }
-          it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue }
-        end
+    context 'when an assignment is failed twice' do
+      before do
+        2.times { assignment.accept_submission_status! :failed }
+      end
 
-        context 'assignment is hard' do
-          before do
-            10.times { assignment.accept_submission_status! :failed }
-            assignment.accept_submission_status! :passed
-          end
+      it 'should count submissions accordingly' do
+        expect(assignment.submissions_count).to eq 2
+      end
 
-          it { expect(assignment.submissions_count).to eq 11 }
-          it { expect(assignment.status).to eq :passed }
-          it { expect(assignment.easy?).to be false }
-          it { expect(assignment.hard?).to be true }
-          it { expect(assignment.should_retry?).to be true }
+      it 'should not be easy or hard' do
+        pending("Currently true for easy as it's not checking if the assignment is passed")
+        expect(assignment.easy?).to be false
+        expect(assignment.hard?).to be false
+      end
 
-          it { expect(assignment.next_item_suggestion_type).to eq :practice }
-          it { expect(assignment.next_suggested_item).to be_practice }
+      it 'should know its status' do
+        expect(assignment.status).to eq :failed
+      end
+    end
+  end
 
-          it { expect(assignment.item).to eq exercises[0] }
-          it { expect(assignment.next_item).to eq exercises[1] }
+  describe 'items' do
+    context 'for the last assignment' do
+      let(:assignment) { assignments[2] }
 
-          it { expect(assignment.parent).to eq guide_assignment }
-          it { expect(assignment.siblings).to eq [exercise_assignments[1], exercise_assignments[2]] }
-          it { expect(assignment.sibling_items).to eq [exercises[1], exercises[2]] }
+      it 'should know the assignments item' do
+        expect(assignment.item).to eq exercises[2]
+      end
 
-          it { expect(assignment.next_items).to eq [exercises[1], exercises[2]] }
+      it 'should have no next items' do
+        expect(assignment.next_items).to be_empty
+      end
+    end
 
+    context 'for a non-trailing assignment' do
+      it 'should know the assignments item' do
+        expect(assignment.item).to eq exercises[0]
+      end
 
-          it { expect(assignment.next_suggested_item).to eq exercises[1] }
-          it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue }
-        end
+      it 'should know the next items' do
+        expect(assignment.next_items).to eq [exercises[1], exercises[2]]
+      end
+    end
+  end
 
-        context 'when there is no exercise that matches the suggestion' do
-          let(:assignment) { exercise_assignments[1] }
+  describe 'exercises with same tags' do
+    context 'when no exercises have been solved' do
+      it 'should not suggest anything' do
+        expect { assignment.next_item_suggestion }.to raise_error('can not suggest until closed')
+      end
+    end
 
-           before do
-            10.times { assignment.accept_submission_status! :failed }
-            assignment.accept_submission_status! :passed
-          end
+    context 'when one exercise has been solved' do
+      before do
+        assignment.accept_submission_status! :passed
+      end
 
-          it { expect(assignment.hard?).to be true }
-          it { expect(assignment.next_item_suggestion_type).to eq :practice }
+      it 'should suggest to continue with the next exercise' do
+        expect(assignment.next_suggested_item).to eq exercises[1]
+        expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue
+      end
+    end
 
-          it { expect(assignment.next_item).to eq exercises[2] }
+    context 'when two learning exercises of a certain tag were solved easily' do
+      let(:assignment) { assignments[1] }
 
-          it { expect(assignment.next_item_suggestion_type).to eq :practice }
-          it { expect(assignment.next_suggested_item).to be_learning }
+      before do
+        assignments[0].accept_submission_status! :passed
+        assignment.accept_submission_status! :passed
+      end
 
-          it { expect(assignment.next_suggested_item).to eq exercises[2] }
-          it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue }
-        end
+      it 'should suggest to skip a third exercise' do
+        expect(assignment.next_suggested_item).to eq exercises[2]
+        expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Skip
+      end
+    end
+
+    context 'when no exercises of a certain tag were solved easily' do
+      let(:assignment) { assignments[1] }
+
+      before do
+        5.times { assignments[0].accept_submission_status! :passed }
+        5.times { assignment.accept_submission_status! :passed }
+
+        assignments[0].accept_submission_status! :passed
+        assignment.accept_submission_status! :passed
+      end
+
+      it 'should suggest to continue with the next exercise' do
+        expect(assignment.next_suggested_item).to eq exercises[2]
+        expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue
       end
     end
   end

--- a/spec/mumukit/assignment_spec.rb
+++ b/spec/mumukit/assignment_spec.rb
@@ -115,8 +115,8 @@ describe Mumukit::Flow::Assignment do
           it { expect(assignment.next_item).to eq exercises[1] }
           it { expect(assignment.next_items).to eq [exercises[1], exercises[2]] }
 
-          it { expect(assignment.next_suggested_item).to eq exercises[2] }
-          it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Skip }
+          it { expect(assignment.next_suggested_item).to eq exercises[1] }
+          it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue }
         end
 
         context 'assignment is normal' do

--- a/spec/mumukit/assignment_spec.rb
+++ b/spec/mumukit/assignment_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Mumukit::Flow::Assignment do
-
   let(:exercises) { [
     DemoExercise.new(:learning),
     DemoExercise.new(:learning),
@@ -142,9 +141,23 @@ describe Mumukit::Flow::Assignment do
         assignment.accept_submission_status! :passed
       end
 
-      it 'should suggest to skip a third exercise' do
-        expect(assignment.next_suggested_item).to eq exercises[2]
-        expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Skip
+      context 'when the third exercise is practice' do
+        it 'should suggest to skip it' do
+          expect(assignment.next_suggested_item).to eq exercises[2]
+          expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Skip
+        end
+      end
+
+      context 'when the third exercise is learning' do
+        before do
+          exercises[2] = DemoExercise.new(:learning)
+          assignments_for(exercises)
+        end
+
+        it 'should suggest to continue with it' do
+          expect(assignment.next_suggested_item).to eq exercises[2]
+          expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Continue
+        end
       end
     end
 

--- a/spec/mumukit/assignment_spec.rb
+++ b/spec/mumukit/assignment_spec.rb
@@ -45,8 +45,8 @@ describe Mumukit::Flow::Assignment do
         it { expect(assignment.next_item).to eq nil }
         it { expect(assignment.next_items).to eq [] }
 
-        pending { expect(assignment.next_suggested_item).to eq exercises[1] }
-        pending { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Retry }
+        it { expect(assignment.next_suggested_item).to eq nil }
+        it { expect(assignment.next_item_suggestion).to be Mumukit::Flow::Suggestion::None }
       end
 
       context 'when previous exercises have being hard to solve' do
@@ -61,8 +61,8 @@ describe Mumukit::Flow::Assignment do
         it { expect(assignment.next_item).to eq nil }
         it { expect(assignment.next_items).to eq [] }
 
-        it { expect(assignment.next_suggested_item).to eq exercises[1] }
-        it { expect(assignment.next_item_suggestion).to be_a Mumukit::Flow::Suggestion::Retry }
+        it { expect(assignment.next_suggested_item).to eq nil }
+        it { expect(assignment.next_item_suggestion).to be Mumukit::Flow::Suggestion::None }
       end
 
       context 'when there is a single pending exercises' do

--- a/spec/mumukit/assignment_spec.rb
+++ b/spec/mumukit/assignment_spec.rb
@@ -80,7 +80,6 @@ describe Mumukit::Flow::Assignment do
       end
 
       it 'should not be easy or hard' do
-        pending("Currently true for easy as it's not checking if the assignment is passed")
         expect(assignment.easy?).to be false
         expect(assignment.hard?).to be false
       end

--- a/spec/mumukit/difficulty_spec.rb
+++ b/spec/mumukit/difficulty_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'difficulty' do
 
   describe 'track_failure!' do
-    context 'no failures' do
+    pending 'no failures' do
       let(:difficulty) { Mumukit::Flow::Difficulty.new }
 
       it { expect(difficulty.level).to eq 0 }
@@ -14,7 +14,7 @@ describe 'difficulty' do
       it { expect(difficulty.next_item_suggestion_type).to be :learning }
     end
 
-    context 'fail once' do
+    pending 'fail once' do
       let(:difficulty) { Mumukit::Flow::Difficulty.new 1 }
 
       it { expect(difficulty.level).to eq 1 }
@@ -25,7 +25,7 @@ describe 'difficulty' do
       it { expect(difficulty.next_item_suggestion_type).to be :learning }
     end
 
-    context 'fail twice' do
+    pending 'fail twice' do
       let(:difficulty) { Mumukit::Flow::Difficulty.new 2 }
 
       it { expect(difficulty.level).to eq 2 }
@@ -36,7 +36,7 @@ describe 'difficulty' do
       it { expect(difficulty.next_item_suggestion_type).to be :learning }
     end
 
-    context 'four failures' do
+    pending 'four failures' do
       let(:difficulty) { Mumukit::Flow::Difficulty.new 4 }
 
       it { expect(difficulty.level).to eq 4 }
@@ -47,7 +47,7 @@ describe 'difficulty' do
       it { expect(difficulty.next_item_suggestion_type).to be :practice }
     end
 
-    context 'ten failures' do
+    pending 'ten failures' do
       let(:difficulty) { Mumukit::Flow::Difficulty.new 10 }
 
       it { expect(difficulty.level).to eq 10 }

--- a/spec/mumukit/difficulty_spec.rb
+++ b/spec/mumukit/difficulty_spec.rb
@@ -1,61 +1,92 @@
 require 'spec_helper'
 
 describe 'difficulty' do
+  let(:exercises) { [ DemoExercise.new(:learning) ] }
 
-  describe 'track_failure!' do
-    pending 'no failures' do
-      let(:difficulty) { Mumukit::Flow::Difficulty.new }
+  let(:assignments) { assignments_for(exercises) }
+  let(:assignment) { assignments[0] }
 
-      it { expect(difficulty.level).to eq 0 }
-      it { expect(difficulty.easy?).to be true }
-      it { expect(difficulty.hard?).to be false }
+  describe 'passing an assignment' do
+    context 'with no failures' do
+      before do
+        assignment.accept_submission_status! :passed
+      end
 
-      it { expect(difficulty.should_retry?).to be false }
-      it { expect(difficulty.next_item_suggestion_type).to be :learning }
+      it 'should be easy' do
+        expect(assignment.easy?).to be true
+        expect(assignment.hard?).to be false
+      end
     end
 
-    pending 'fail once' do
-      let(:difficulty) { Mumukit::Flow::Difficulty.new 1 }
+    context 'with two failures' do
+      before do
+        2.times { assignment.accept_submission_status! :failed }
+        assignment.accept_submission_status! :passed
+      end
 
-      it { expect(difficulty.level).to eq 1 }
-      it { expect(difficulty.easy?).to be true }
-      it { expect(difficulty.hard?).to be false }
-
-      it { expect(difficulty.should_retry?).to be false }
-      it { expect(difficulty.next_item_suggestion_type).to be :learning }
+      it 'should be easy' do
+        expect(assignment.easy?).to be true
+        expect(assignment.hard?).to be false
+      end
     end
 
-    pending 'fail twice' do
-      let(:difficulty) { Mumukit::Flow::Difficulty.new 2 }
+    context 'with three failures' do
+      before do
+        3.times { assignment.accept_submission_status! :failed }
+        assignment.accept_submission_status! :passed
+      end
 
-      it { expect(difficulty.level).to eq 2 }
-      it { expect(difficulty.easy?).to be true }
-      it { expect(difficulty.hard?).to be false }
-
-      it { expect(difficulty.should_retry?).to be false }
-      it { expect(difficulty.next_item_suggestion_type).to be :learning }
+      it 'should not be easy or hard' do
+        expect(assignment.easy?).to be false
+        expect(assignment.hard?).to be false
+      end
     end
 
-    pending 'four failures' do
-      let(:difficulty) { Mumukit::Flow::Difficulty.new 4 }
+    context 'with ten failures' do
+      before do
+        10.times { assignment.accept_submission_status! :failed }
+        assignment.accept_submission_status! :passed
+      end
 
-      it { expect(difficulty.level).to eq 4 }
-      it { expect(difficulty.easy?).to be false }
-      it { expect(difficulty.hard?).to be false }
+      it 'should be hard' do
+        expect(assignment.easy?).to be false
+        expect(assignment.hard?).to be true
+      end
+    end
+  end
 
-      it { expect(difficulty.should_retry?).to be false }
-      it { expect(difficulty.next_item_suggestion_type).to be :practice }
+  describe 'failing an assignment' do
+    context 'once' do
+      before do
+        assignment.accept_submission_status! :failed
+      end
+
+      it 'should not be easy or hard' do
+        expect(assignment.easy?).to be false
+        expect(assignment.hard?).to be false
+      end
     end
 
-    pending 'ten failures' do
-      let(:difficulty) { Mumukit::Flow::Difficulty.new 10 }
+    context 'three times' do
+      before do
+        3.times { assignment.accept_submission_status! :failed }
+      end
 
-      it { expect(difficulty.level).to eq 10 }
-      it { expect(difficulty.easy?).to be false }
-      it { expect(difficulty.hard?).to be true }
+      it 'should not be easy or hard' do
+        expect(assignment.easy?).to be false
+        expect(assignment.hard?).to be false
+      end
+    end
 
-      it { expect(difficulty.should_retry?).to be true }
-      it { expect(difficulty.next_item_suggestion_type).to be :practice }
+    context 'ten times' do
+      before do
+        10.times { assignment.accept_submission_status! :failed }
+      end
+
+      it 'should be hard' do
+        expect(assignment.easy?).to be false
+        expect(assignment.hard?).to be true
+      end
     end
   end
 end

--- a/spec/mumukit/guide_flow_integration_spec.rb
+++ b/spec/mumukit/guide_flow_integration_spec.rb
@@ -37,7 +37,7 @@ describe 'guide flow integration' do
     expect(flow.total_submissions_count).to eq 11
   end
 
-  it "1: hard, 2: easy, 3: easy, 1: easy" do
+  it "1: hard, 2: easy, 3: easy" do
     expect(flow.current_exercise_number).to be 1
 
     10.times { flow.submit! :failed }
@@ -48,14 +48,11 @@ describe 'guide flow integration' do
     expect(flow.current_exercise_number).to be 3
 
     flow.submit! :passed
-    expect(flow.current_exercise_number).to be 1
-
-    flow.submit! :passed
     expect(flow.current_exercise_number).to be nil
 
     expect(flow).to be_finished
     expect(flow).to be_closed
-    expect(flow.total_submissions_count).to eq 14
+    expect(flow.total_submissions_count).to eq 13
   end
 
   it "[mixed submissions] 1: normal, 2: normal, 3: normal" do
@@ -159,7 +156,7 @@ describe 'guide flow integration' do
     expect(flow.total_submissions_count).to eq 15
   end
 
-  it "1: hard, 2: easy, 3: easy, 1: hard" do
+  it "1: hard, 2: easy, 3: easy" do
     expect(flow.current_exercise_number).to be 1
 
     10.times { flow.submit! :failed }
@@ -170,15 +167,11 @@ describe 'guide flow integration' do
     expect(flow.current_exercise_number).to be 3
 
     flow.submit! :passed
-    expect(flow.current_exercise_number).to be 1
-
-    10.times { flow.submit! :failed }
-    flow.submit! :passed
     expect(flow.current_exercise_number).to be nil
 
     expect(flow).to be_finished
     expect(flow).to be_closed
-    expect(flow.total_submissions_count).to eq 24
+    expect(flow.total_submissions_count).to eq 13
   end
 
   pending "1: hard, 2: hard, 3: easy, 1: hard, 1: hard" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,13 @@ RSpec.configure do |config|
   end
 end
 
+def assignments_for(exercises)
+  assignments = exercises.map { |exercise| DemoExerciseAssignment.new(exercise) }
+  guide = DemoGuide.new(exercises)
+  guide_assignment = DemoGuideAssignment.new(guide, assignments)
+
+  guide_assignment.children
+end
 
 class DemoBaseAssignment
   include Mumukit::Flow::Assignment
@@ -65,9 +72,9 @@ end
 
 class DemoExercise < DemoBaseContent
   attr_accessor :number, :tags
-  def initialize(type)
+  def initialize(type, tags=['A', 'B'])
     @type = type
-    @tags = ['A', 'B']
+    @tags = tags
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,9 +64,10 @@ class DemoBaseContent
 end
 
 class DemoExercise < DemoBaseContent
-  attr_accessor :number
+  attr_accessor :number, :tags
   def initialize(type)
     @type = type
+    @tags = ['A', 'B']
   end
 end
 


### PR DESCRIPTION
:warning: This is a work in progress, not to be merged yet :warning: 

This PR revamps some ideas for an adaptive flow, such as:

- Retrying an exercise is no longer a suggestion option
- Adding new rules for skipping exercises. Now we not only base it on whether it's a learning or practice exercise, but also on:
   - Previous performance
   - Exercise tags, which should hopefully group conceptually similar exercises

Almost all specs have been redone to suit these and other preexisting ideas better. A few integration specs remain pending, however, which will be fixed once some real integration is done.