### PR TITLE
Migrate navigation modules from Domain

### DIFF
--- a/lib/mumukit/flow.rb
+++ b/lib/mumukit/flow.rb
@@ -1,4 +1,4 @@
-require "mumukit/flow/version"
+require 'mumukit/flow/version'
 require 'mumukit/core'
 
 module Mumukit
@@ -6,7 +6,8 @@ module Mumukit
   end
 end
 
-require_relative './flow/suggestion'
-require_relative './flow/suggesting'
-require_relative './flow/adaptive_assignment'
-require_relative './flow/adaptive_item'
+require_relative 'flow/navigation'
+require_relative 'flow/suggesting'
+require_relative 'flow/suggestion'
+require_relative 'flow/adaptive_assignment'
+require_relative 'flow/adaptive_item'

--- a/lib/mumukit/flow/adaptive_item.rb
+++ b/lib/mumukit/flow/adaptive_item.rb
@@ -3,8 +3,8 @@ module Mumukit::Flow
     include Mumukit::Flow::Suggesting
 
     required :assignment
-    required :children
-    required :parent
+    required :structural_children
+    required :structural_parent
     required :tags
 
     delegate :passed?, :submitter, to: :@assignment
@@ -46,7 +46,7 @@ module Mumukit::Flow
 
     def pending_siblings
       passed_items = passed_siblings_by(submitter).map(&:item)
-      parent.children - passed_items
+      structural_parent.structural_children - passed_items
     end
 
     def first_pending_sibling
@@ -58,7 +58,7 @@ module Mumukit::Flow
     end
 
     def passed_siblings_by(submitter)
-      parent.exercise_assignments_for(submitter).select(&:passed?)
+      structural_parent.exercise_assignments_for(submitter).select(&:passed?)
     end
 
     def similar_easy_siblings_for_every_tag?

--- a/lib/mumukit/flow/navigation.rb
+++ b/lib/mumukit/flow/navigation.rb
@@ -1,0 +1,3 @@
+require_relative 'navigation/parent_navigation'
+require_relative 'navigation/siblings_navigation'
+require_relative 'navigation/terminal_navigation'

--- a/lib/mumukit/flow/navigation/parent_navigation.rb
+++ b/lib/mumukit/flow/navigation/parent_navigation.rb
@@ -1,0 +1,26 @@
+module Mumukit::Flow::ParentNavigation
+  required :structural_parent
+
+  def leave(user)
+    navigable_parent.next_for(user)
+  end
+
+  def navigation_end?
+    false
+  end
+
+  def navigable_name
+    defaulting_name { super }
+  end
+
+  def navigable_parent
+    structural_parent.usage_in_organization
+  end
+
+  private
+
+  def defaulting_name(&block)
+    navigable_parent.defaulting(name, &block)
+  end
+end
+

--- a/lib/mumukit/flow/navigation/parent_navigation.rb
+++ b/lib/mumukit/flow/navigation/parent_navigation.rb
@@ -1,5 +1,6 @@
 module Mumukit::Flow::ParentNavigation
   required :structural_parent
+  required :name
 
   def leave(user)
     navigable_parent.next_for(user)

--- a/lib/mumukit/flow/navigation/siblings_navigation.rb
+++ b/lib/mumukit/flow/navigation/siblings_navigation.rb
@@ -16,11 +16,9 @@ module Mumukit::Flow::SiblingsNavigation
     structural_parent.structural_children
   end
 
-  def pending_siblings_for(user, organization=Organization.current)
-    siblings.reject { |it| it.progress_for(user, organization).completed? }
+  def pending_siblings_for(user)
+    siblings.reject { |it| it.progress_for(user).completed? }
   end
-
-  # Names
 
   def navigable_name
     "#{number}. #{name}"

--- a/lib/mumukit/flow/navigation/siblings_navigation.rb
+++ b/lib/mumukit/flow/navigation/siblings_navigation.rb
@@ -1,0 +1,25 @@
+module Mumukit::Flow::SiblingsNavigation
+  required :pending_siblings_for
+
+  def next_for(user)
+    pending_siblings_for(user).select { |it| it.number > number }.sort_by(&:number).first
+  end
+
+  def restart(user)
+    pending_siblings_for(user).sort_by(&:number).first
+  end
+
+  def siblings
+    structural_parent.structural_children
+  end
+
+  def pending_siblings_for(user, organization=Organization.current)
+    siblings.reject { |it| it.progress_for(user, organization).completed? }
+  end
+
+  # Names
+
+  def navigable_name
+    "#{number}. #{name}"
+  end
+end

--- a/lib/mumukit/flow/navigation/siblings_navigation.rb
+++ b/lib/mumukit/flow/navigation/siblings_navigation.rb
@@ -1,5 +1,8 @@
 module Mumukit::Flow::SiblingsNavigation
-  required :pending_siblings_for
+  required :structural_parent
+  required :progress_for
+  required :number
+  required :name
 
   def next_for(user)
     pending_siblings_for(user).select { |it| it.number > number }.sort_by(&:number).first

--- a/lib/mumukit/flow/navigation/terminal_navigation.rb
+++ b/lib/mumukit/flow/navigation/terminal_navigation.rb
@@ -1,0 +1,21 @@
+module Mumukit::Flow::TerminalNavigation
+  def navigation_end?
+    true
+  end
+
+  def friendly
+    name
+  end
+
+  def navigable_name
+    name
+  end
+
+  def structural_parent
+    nil
+  end
+
+  def siblings
+    []
+  end
+end

--- a/lib/mumukit/flow/navigation/terminal_navigation.rb
+++ b/lib/mumukit/flow/navigation/terminal_navigation.rb
@@ -1,4 +1,6 @@
 module Mumukit::Flow::TerminalNavigation
+  required :name
+
   def navigation_end?
     true
   end

--- a/spec/mumukit/navigation/leaf_navigable_spec.rb
+++ b/spec/mumukit/navigation/leaf_navigable_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'mumukit/navigation/navigation_spec_helper.rb'
+
+describe 'ParentNavigation, SiblingsNavigation' do
+  let(:leaf) { LeafNavigable.new }
+
+  describe '#leave' do
+    it { expect(leaf.leave('user')).to be_a LeafNavigable }
+  end
+
+  describe '#navigation_end?' do
+    it { expect(leaf.navigation_end?).to be false }
+  end
+
+  describe '#navigable_name' do
+    it { expect(leaf.navigable_name).to eq '1. Leaf' }
+  end
+
+  describe '#navigable_parent' do
+    it { expect(leaf.navigable_parent).to be_a SubRootNavigable }
+  end
+
+  # describe '#structural_parent' do
+  #   it { expect(leaf.structural_parent).to be_a StructuralParent }
+  # end
+
+  describe '#next_for' do
+    it { expect(leaf.next_for('user')).to be_a LeafNavigable }
+  end
+
+  describe '#restart' do
+    it { expect(leaf.restart('user')).to be_a LeafNavigable }
+  end
+
+  describe '#siblings' do
+    it { expect(leaf.siblings).to all(be_a LeafNavigable) }
+  end
+
+  describe '#pending_siblings_for' do
+    it { expect(leaf.pending_siblings_for('user')).to all(be_a LeafNavigable) }
+  end
+end

--- a/spec/mumukit/navigation/navigation_spec_helper.rb
+++ b/spec/mumukit/navigation/navigation_spec_helper.rb
@@ -1,0 +1,58 @@
+class RootNavigable
+  include Mumukit::Flow::TerminalNavigation
+
+  def name
+    'Root'
+  end
+end
+
+class SubRootNavigable
+  include Mumukit::Flow::ParentNavigation
+
+  def defaulting(_block)
+    'SubRoot'
+  end
+
+  def next_for(_user)
+    LeafNavigable.new
+  end
+end
+
+class LeafNavigable
+  include Mumukit::Flow::ParentNavigation
+  include Mumukit::Flow::SiblingsNavigation
+
+  attr_reader :number
+
+  def initialize(number=1)
+    @number = number
+  end
+
+  def structural_parent
+    StructuralParent.new
+  end
+
+  def progress_for(_user)
+    DemoProgress.new
+  end
+
+  def name
+    'Leaf'
+  end
+end
+
+class StructuralParent
+  def structural_children
+    [LeafNavigable.new(1), LeafNavigable.new(2), LeafNavigable.new(3)]
+  end
+
+  def usage_in_organization
+    SubRootNavigable.new
+  end
+end
+
+class DemoProgress
+  def completed?
+    false
+  end
+end

--- a/spec/mumukit/navigation/root_navigable_spec.rb
+++ b/spec/mumukit/navigation/root_navigable_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'mumukit/navigation/navigation_spec_helper.rb'
+
+describe 'TerminalNavigation' do
+  let(:root) { RootNavigable.new }
+
+  describe '#navigation_end?' do
+    it { expect(root.navigation_end?).to be true }
+  end
+
+  describe '#friendly' do
+    it { expect(root.friendly).to eq 'Root' }
+  end
+
+  describe '#navigable_name' do
+    it { expect(root.navigable_name).to eq 'Root' }
+  end
+
+  describe '#structural_parent' do
+    it { expect(root.structural_parent).to be nil }
+  end
+
+  describe '#siblings' do
+    it { expect(root.siblings).to be_empty }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,7 @@ end
 class DemoBaseContent
   include Mumukit::Flow::AdaptiveItem
 
-  attr_accessor :parent
+  attr_accessor :structural_parent
 
   def learning?
     @type == :learning
@@ -73,15 +73,15 @@ class DemoExercise < DemoBaseContent
 end
 
 class DemoGuide < DemoBaseContent
-  attr_accessor :children
+  attr_accessor :structural_children
 
   def initialize(exercises)
-    @children = exercises
+    @structural_children = exercises
     exercises.merge_numbers!
-    exercises.each { |it| it.parent = self }
+    exercises.each { |it| it.structural_parent = self }
   end
 
   def exercise_assignments_for(_submitter)
-    children.map(&:assignment)
+    structural_children.map(&:assignment)
   end
 end


### PR DESCRIPTION
This PR welcomes some navigation modules which were previously on mumuki-domain.

Domain, on its part, loses them in its own PR: https://github.com/mumuki/mumuki-domain/pull/70