### PR TITLE
Limit skipping to exercises with tags only

### DIFF
--- a/lib/mumukit/flow/adaptive_item.rb
+++ b/lib/mumukit/flow/adaptive_item.rb
@@ -13,6 +13,10 @@ module Mumukit::Flow
       tags.include? tag
     end
 
+    def no_tags?
+      tags.empty?
+    end
+
     def should_skip_next_item?
       similar_easy_siblings_for_every_tag? if next_item&.skippable?
     end
@@ -62,7 +66,11 @@ module Mumukit::Flow
     end
 
     def similar_easy_siblings_for_every_tag?
-      next_item.tags.all? { |tag| easy_siblings_with(tag).count >= min_easy_siblings_for_skipping }
+      next_item.tags.all?{ |tag| easy_tag?(tag) } unless next_item.no_tags?
+    end
+
+    def easy_tag?(tag)
+      easy_siblings_with(tag).count >= min_easy_siblings_for_skipping
     end
 
     def easy_siblings_with(tag)

--- a/spec/mumukit/adaptive_item_spec.rb
+++ b/spec/mumukit/adaptive_item_spec.rb
@@ -5,13 +5,14 @@ describe Mumukit::Flow::AdaptiveItem do
       DemoExercise.new(:learning, ['A', 'B']),
       DemoExercise.new(:learning),
       DemoExercise.new(:practice),
-      DemoExercise.new(:learning),
+      DemoExercise.new(:learning, []),
       DemoExercise.new(:learning)
   ] }
   let!(:guide) { DemoGuide.new(exercises) }
   let(:submitter) { 'a student' }
   let(:exercise) { exercises.first }
   let(:practice_exercise) { exercises.third }
+  let(:tagless_exercise) { exercises.fourth }
   let(:last_exercise) { exercises.last }
 
   describe '#tagged_as?' do
@@ -22,6 +23,16 @@ describe Mumukit::Flow::AdaptiveItem do
 
     context 'with a tag it does not have' do
       it { expect(exercise.tagged_as? 'C').to be false }
+    end
+  end
+
+  describe '#no_tags?' do
+    context 'when an exercise has tags' do
+      it { expect(exercise.no_tags?).to be false}
+    end
+
+    context 'when an exercise does not have tags' do
+      it { expect(tagless_exercise.no_tags?).to be true }
     end
   end
 

--- a/spec/mumukit/suggesting_spec.rb
+++ b/spec/mumukit/suggesting_spec.rb
@@ -209,6 +209,46 @@ describe Mumukit::Flow::Suggesting do
     end
   end
 
+  describe 'exercises with no tags' do
+    let(:exercises) { [
+        DemoExercise.new(:learning, []),
+        DemoExercise.new(:learning, []),
+        DemoExercise.new(:practice, [])
+    ] }
+
+    context 'when two learning exercises were solved easily' do
+      before do
+        exercises[0].accept_submission_status! :passed
+        exercises[1].accept_submission_status! :passed
+      end
+
+      context 'when the third exercise is practice' do
+        it 'suggests continuing' do
+          expect(exercise.should_skip_next_item?).to be_falsey
+        end
+
+        it 'with the third one' do
+          expect(exercise.next_suggested_item_for(submitter)).to eq exercises[2]
+        end
+      end
+
+      context 'when the third exercise is learning' do
+        before do
+          exercises[2] = DemoExercise.new(:learning, [])
+          build_guide_with(exercises)
+        end
+
+        it 'suggests continuing' do
+          expect(exercise.should_skip_next_item?).to be_falsey
+        end
+
+        it 'with the third one' do
+          expect(exercise.next_suggested_item_for(submitter)).to eq exercises[2]
+        end
+      end
+    end
+  end
+
   describe 'exercises solved out of turn' do
     context 'when the last two exercises have been solved' do
       before do


### PR DESCRIPTION
Closes #6.

Makes a few small changes to make sure we're not skipping around unless the exercises are tagged.